### PR TITLE
Hot Fix for Routing Issue in MenuItemReview

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -244,12 +244,12 @@ function App() {
           <>
             <Route
               exact
-              path="/menuitemreview/edit/:id"
+              path="/menuitemreviews/edit/:id"
               element={<MenuItemReviewEditPage />}
             />
             <Route
               exact
-              path="/menuitemreview/create"
+              path="/menuitemreviews/create"
               element={<MenuItemReviewCreatePage />}
             />
           </>


### PR DESCRIPTION
The Create and Edit pages for MenuItemReview were erroneously routed to menutitemreview instead of menuitemreviews which is consistent with the API name. This fixes the issue!